### PR TITLE
Feature: Add time control key binds.

### DIFF
--- a/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
+++ b/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
@@ -2,7 +2,9 @@ package org.polyfrost.polytime.config
 
 import cc.polyfrost.oneconfig.config.Config
 import cc.polyfrost.oneconfig.config.annotations.*
+import cc.polyfrost.oneconfig.config.core.OneKeyBind
 import cc.polyfrost.oneconfig.config.data.*
+import cc.polyfrost.oneconfig.libs.universal.UKeyboard
 import org.polyfrost.polytime.PolyTime
 
 
@@ -52,12 +54,32 @@ object ModConfig : Config(Mod(PolyTime.NAME, ModType.UTIL_QOL, "/polytime_dark.s
     var fastSpeed = 1f
         get() = field.coerceIn(0.1f..10f)
 
+    @KeyBind(
+        name = "Forward Key Bind",
+        description = "Moves time forwards when pressed.",
+        category = "Time"
+    )
+    var forwardKeyBind: OneKeyBind = OneKeyBind(UKeyboard.KEY_RBRACKET)
+
+    @KeyBind(
+        name = "Backward Key Bind",
+        description = "Moves time backwards when pressed.",
+        category = "Time"
+    )
+    var backwardKeybind: OneKeyBind = OneKeyBind(UKeyboard.KEY_LBRACKET)
+
     init {
         initialize()
         addDependency("time", "IRL Time") { !irlTime }
+
         //addDependency("irlTime", "Fast Time") { !fastTime }
         //addDependency("time", "IRL Time / Fast Time") { !irlTime && !fastTime }
         //addDependency("fastTime", "IRL Time") { !irlTime }
         //addDependency("fastSpeed", "IRL Time / Fast Time") { !irlTime && fastTime }
+
+        registerKeyBind(forwardKeyBind) { if (time < 24) time += 0.5f; }
+        addDependency("forwardKeyBind", "IRL Time") { !irlTime }
+        registerKeyBind(backwardKeybind) { if (time > 0) time -= 0.5f; }
+        addDependency("backwardKeybind", "IRL Time") { !irlTime }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds keybinds to quickly move time forwards or backwards as Wyvest suggested in the Polyfrost Discord.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #N/A

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- Added keybinds to quickly move time forwards/backwards.
```
<!--
## Documentation
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->