### PR TITLE
 Feature: Add time control key binds.

### DIFF
--- a/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
+++ b/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
@@ -61,14 +61,12 @@ object ModConfig : Config("${PolyTime.MODID}.json", "/polytime_dark.svg", PolyTi
     @Keybind(
         title = "Forward Key Bind",
         description = "Moves time forwards when pressed.",
-        category = "Time"
     )
     var forwardKeyBind = KeybindHelper.builder().keys(UKeyboard.KEY_RBRACKET).does { if (time < 24) time += 0.5f }.register()
 
     @Keybind(
         title = "Backward Key Bind",
         description = "Moves time backwards when pressed.",
-        category = "Time"
     )
     var backwardKeybind = KeybindHelper.builder().keys(UKeyboard.KEY_LBRACKET).does { if (time > 0) time -= 0.5f }.register()
 

--- a/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
+++ b/src/main/kotlin/org/polyfrost/polytime/config/ModConfig.kt
@@ -1,12 +1,14 @@
 package org.polyfrost.polytime.config
 
-
 import org.polyfrost.oneconfig.api.config.v1.Config
 import org.polyfrost.oneconfig.api.config.v1.annotations.Checkbox
+import org.polyfrost.oneconfig.api.config.v1.annotations.Keybind
 import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
 import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
+import org.polyfrost.oneconfig.api.ui.v1.keybind.KeybindHelper
+import org.polyfrost.oneconfig.api.ui.v1.keybind.KeybindManager.registerKeybind
 import org.polyfrost.polytime.PolyTime
-
+import org.polyfrost.universal.UKeyboard
 
 object ModConfig : Config("${PolyTime.MODID}.json", "/polytime_dark.svg", PolyTime.NAME, Category.QOL) {
 
@@ -56,6 +58,20 @@ object ModConfig : Config("${PolyTime.MODID}.json", "/polytime_dark.svg", PolyTi
     // var fastSpeed = 1f
     //     get() = field.coerceIn(0.1f..10f)
 
+    @Keybind(
+        title = "Forward Key Bind",
+        description = "Moves time forwards when pressed.",
+        category = "Time"
+    )
+    var forwardKeyBind = KeybindHelper.builder().keys(UKeyboard.KEY_RBRACKET).does { if (time < 24) time += 0.5f }.register()
+
+    @Keybind(
+        title = "Backward Key Bind",
+        description = "Moves time backwards when pressed.",
+        category = "Time"
+    )
+    var backwardKeybind = KeybindHelper.builder().keys(UKeyboard.KEY_LBRACKET).does { if (time > 0) time -= 0.5f }.register()
+
     init {
         // initialize()
         addDependency("time", "IRL Time") { !irlTime }
@@ -63,5 +79,10 @@ object ModConfig : Config("${PolyTime.MODID}.json", "/polytime_dark.svg", PolyTi
         //addDependency("time", "IRL Time / Fast Time") { !irlTime && !fastTime }
         //addDependency("fastTime", "IRL Time") { !irlTime }
         //addDependency("fastSpeed", "IRL Time / Fast Time") { !irlTime && fastTime }
+
+        registerKeybind(forwardKeyBind)
+        addDependency("forwardKeyBind", "IRL Time") { !irlTime }
+        registerKeybind(backwardKeybind)
+        addDependency("backwardKeybind", "IRL Time") { !irlTime }
     }
 }


### PR DESCRIPTION
## Description
Same as #1 just twoconfig.
Adds keybinds to quickly move time forwards or backwards as Wyvest suggested in the Polyfrost Discord.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #N/A

<!-- ## How to test Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- Added keybinds to quickly move time forwards/backwards.
```
<!--
## Documentation
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->