### PR TITLE
prevent sky shaking by setting partialTicks to 1 in renderSky

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name = PolyTime
 mod_id = polytime
-mod_version = 1.0.2
+mod_version = 1.0.3
 mod_archives_name = PolyTime
 
 polyfrost.defaults.loom=3

--- a/src/main/java/org/polyfrost/polytime/mixin/RenderGlobalMixin.java
+++ b/src/main/java/org/polyfrost/polytime/mixin/RenderGlobalMixin.java
@@ -1,0 +1,18 @@
+package org.polyfrost.polytime.mixin;
+
+import net.minecraft.client.renderer.RenderGlobal;
+import org.polyfrost.polytime.config.ModConfig;
+import net.minecraftforge.fml.relauncher.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@SideOnly(Side.CLIENT)
+@Mixin(RenderGlobal.class)
+public class RenderGlobalMixin {
+    @ModifyVariable(method = "renderSky(FI)V", at = @At(value = "HEAD"), ordinal = 0, argsOnly = true)
+    public float injectStaticSky(float value) {
+        if (!ModConfig.INSTANCE.enabled) return value;
+        return 1f;
+    }
+}

--- a/src/main/resources/mixins.polytime.json
+++ b/src/main/resources/mixins.polytime.json
@@ -5,6 +5,7 @@
   "refmap": "mixins.polytime.refmap.json",
   "verbose": true,
   "client": [
+    "RenderGlobalMixin",
     "WorldInfoMixin",
     "WorldProviderMixin"
   ]


### PR DESCRIPTION
## Description
Force partialTicks in renderSky with a Mixin to be 1 if the mod is enabled to prevent the sky from “shaking” or "jittering" as renderSky gets called every frame and uses partial ticks to have smooth rotation

## Related Issue(s)
Fixes #N/A

## How to test
Use current version of the mod and disable the sky with Optifine in: Options… -> Video Settings… -> Sky 
If you have a custom sky box from a texturepack you'll see it shake if you zoom far in
This no longer happens after my fix.

## Release Notes
```release-note
fix: prevent sky shaking when PolyTime is enabled
```
